### PR TITLE
add placeholder image to item get route

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -2,7 +2,7 @@ var mongoose = require("mongoose");
 var uniqueValidator = require("mongoose-unique-validator");
 var slug = require("slug");
 var User = mongoose.model("User");
-var placeholder = '/placeholder.png';
+var placeholder = "/placeholder.png";
 
 var ItemSchema = new mongoose.Schema(
   {

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -2,6 +2,7 @@ var mongoose = require("mongoose");
 var uniqueValidator = require("mongoose-unique-validator");
 var slug = require("slug");
 var User = mongoose.model("User");
+var placeholder = '/placeholder.png';
 
 var ItemSchema = new mongoose.Schema(
   {
@@ -49,7 +50,7 @@ ItemSchema.methods.toJSONFor = function (user) {
     slug: this.slug,
     title: this.title,
     description: this.description,
-    image: this.image,
+    image: this.image || placeholder,
     createdAt: this.createdAt,
     updatedAt: this.updatedAt,
     tagList: this.tagList,

--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -2,7 +2,8 @@ var mongoose = require("mongoose");
 var uniqueValidator = require("mongoose-unique-validator");
 var slug = require("slug");
 var User = mongoose.model("User");
-var placeholder = "/placeholder.png";
+
+const placeholder = "/placeholder.png";
 
 var ItemSchema = new mongoose.Schema(
   {

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -5,7 +5,6 @@ var Comment = mongoose.model("Comment");
 var User = mongoose.model("User");
 var auth = require("../auth");
 const { sendEvent } = require("../../lib/event");
-const { placeholder } = require("../../../frontend/public/placeholder.png");
 
 // Preload item objects on routes with ':item'
 router.param("item", function (req, res, next, slug) {

--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -5,6 +5,7 @@ var Comment = mongoose.model("Comment");
 var User = mongoose.model("User");
 var auth = require("../auth");
 const { sendEvent } = require("../../lib/event");
+const { placeholder } = require("../../../frontend/public/placeholder.png");
 
 // Preload item objects on routes with ':item'
 router.param("item", function (req, res, next, slug) {
@@ -182,6 +183,10 @@ router.put("/:item", auth.required, function (req, res, next) {
 
       if (typeof req.body.item.description !== "undefined") {
         req.item.description = req.body.item.description;
+      }
+
+      if (typeof req.body.item.image === "undefined") {
+        placeholder = req.body.item.image;
       }
 
       if (typeof req.body.item.image !== "undefined") {

--- a/backend/tests/api-tests.postman.json
+++ b/backend/tests/api-tests.postman.json
@@ -6,35 +6,40 @@
     "description": "Collection for testing the Anythink-Market API\n\nhttps://github.com/gothinkster/realworld",
     "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
   },
-  "item": [{
+  "item": [
+    {
       "name": "Auth",
       "description": "",
-      "item": [{
+      "item": [
+        {
           "name": "Register",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "if (!(environment.isIntegrationTest)) {",
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
-                "",
-                "var user = responseJSON.user || {};",
-                "",
-                "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
-                "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
-                "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!(environment.isIntegrationTest)) {",
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
+                  "",
+                  "var user = responseJSON.user || {};",
+                  "",
+                  "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
+                  "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
+                  "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/users",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -55,28 +60,31 @@
         },
         {
           "name": "Login",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
-                "",
-                "var user = responseJSON.user || {};",
-                "",
-                "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
-                "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
-                "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
+                  "",
+                  "var user = responseJSON.user || {};",
+                  "",
+                  "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
+                  "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
+                  "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/users/login",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -97,34 +105,37 @@
         },
         {
           "name": "Login and Remember Token",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
-                "",
-                "var user = responseJSON.user || {};",
-                "",
-                "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
-                "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
-                "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
-                "",
-                "if(tests['User has \"token\" property']){",
-                "    postman.setEnvironmentVariable('token', user.token);",
-                "}",
-                "",
-                "tests['Environment variable \"token\" has been set'] = environment.token === user.token;",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
+                  "",
+                  "var user = responseJSON.user || {};",
+                  "",
+                  "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
+                  "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
+                  "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
+                  "",
+                  "if(tests['User has \"token\" property']){",
+                  "    postman.setEnvironmentVariable('token', user.token);",
+                  "}",
+                  "",
+                  "tests['Environment variable \"token\" has been set'] = environment.token === user.token;",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/users/login",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -145,28 +156,31 @@
         },
         {
           "name": "Current User",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
-                "",
-                "var user = responseJSON.user || {};",
-                "",
-                "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
-                "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
-                "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
+                  "",
+                  "var user = responseJSON.user || {};",
+                  "",
+                  "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
+                  "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
+                  "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/user",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -189,28 +203,31 @@
         },
         {
           "name": "Update User",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
-                "",
-                "var user = responseJSON.user || {};",
-                "",
-                "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
-                "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
-                "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"user\" property'] = responseJSON.hasOwnProperty('user');",
+                  "",
+                  "var user = responseJSON.user || {};",
+                  "",
+                  "tests['User has \"email\" property'] = user.hasOwnProperty('email');",
+                  "tests['User has \"username\" property'] = user.hasOwnProperty('username');",
+                  "tests['User has \"token\" property'] = user.hasOwnProperty('token');",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/user",
             "method": "PUT",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -239,53 +256,57 @@
     {
       "name": "Items with authentication",
       "description": "",
-      "item": [{
+      "item": [
+        {
           "name": "Feed",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/feed",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -311,51 +332,54 @@
         },
         {
           "name": "All Items",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -381,51 +405,54 @@
         },
         {
           "name": "All Items with auth",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -451,64 +478,65 @@
         },
         {
           "name": "Items by Author",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?seller=johnjacob",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "seller",
+                  "value": "johnjacob"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "seller",
-                "value": "johnjacob"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -534,66 +562,67 @@
         },
         {
           "name": "Items by Author with auth",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?seller=johnjacob",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "seller",
+                  "value": "johnjacob",
+                  "equals": true,
+                  "description": ""
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "seller",
-                "value": "johnjacob",
-                "equals": true,
-                "description": ""
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -616,64 +645,65 @@
         },
         {
           "name": "Items Favorited by Username",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "    ",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "    ",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?favorited=jane",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "favorited",
+                  "value": "jane"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "favorited",
-                "value": "jane"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -699,64 +729,65 @@
         },
         {
           "name": "Items Favorited by Username with auth",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "    ",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "    ",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?favorited=jane",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "favorited",
+                  "value": "jane"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "favorited",
-                "value": "jane"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -782,64 +813,65 @@
         },
         {
           "name": "Items by Tag",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?tag=dragons",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "tag",
+                  "value": "dragons"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "tag",
-                "value": "dragons"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -865,42 +897,45 @@
         },
         {
           "name": "Create Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "if(tests['Item has \"slug\" property']){",
-                "    postman.setEnvironmentVariable('slug', item.slug);",
-                "}",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "if(tests['Item has \"slug\" property']){",
+                  "    postman.setEnvironmentVariable('slug', item.slug);",
+                  "}",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -926,39 +961,42 @@
         },
         {
           "name": "Single Item by slug",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -981,41 +1019,44 @@
         },
         {
           "name": "Update Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "if (!(environment.isIntegrationTest)) {",
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!(environment.isIntegrationTest)) {",
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}",
             "method": "PUT",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1041,41 +1082,44 @@
         },
         {
           "name": "Favorite Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests[\"Item's 'favorited' property is true\"] = item.favorited === true;",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "tests[\"Item's 'favoritesCount' property is greater than 0\"] = item.favoritesCount > 0;",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests[\"Item's 'favorited' property is true\"] = item.favorited === true;",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "tests[\"Item's 'favoritesCount' property is greater than 0\"] = item.favoritesCount > 0;",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}/favorite",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1101,40 +1145,43 @@
         },
         {
           "name": "Unfavorite Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "tests[\"Item's \\\"favorited\\\" property is true\"] = item.favorited === false;",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "tests[\"Item's \\\"favorited\\\" property is true\"] = item.favorited === false;",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}/favorite",
             "method": "DELETE",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1163,53 +1210,57 @@
     {
       "name": "Items",
       "description": "",
-      "item": [{
+      "item": [
+        {
           "name": "All Items",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1230,64 +1281,65 @@
         },
         {
           "name": "Items by Author",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?seller=johnjacob",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "seller",
+                  "value": "johnjacob"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "seller",
-                "value": "johnjacob"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1308,64 +1360,65 @@
         },
         {
           "name": "Items Favorited by Username",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "    ",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "    ",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?favorited=jane",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "favorited",
+                  "value": "jane"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "favorited",
-                "value": "jane"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1386,64 +1439,65 @@
         },
         {
           "name": "Items by Tag",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
-                "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
-                "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
-                "",
-                "    if(responseJSON.items.length){",
-                "        var item = responseJSON.items[0];",
-                "",
-                "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                "    } else {",
-                "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"items\" property'] = responseJSON.hasOwnProperty('items');",
+                  "    tests['Response contains \"itemsCount\" property'] = responseJSON.hasOwnProperty('itemsCount');",
+                  "    tests['itemsCount is an integer'] = Number.isInteger(responseJSON.itemsCount);",
+                  "",
+                  "    if(responseJSON.items.length){",
+                  "        var item = responseJSON.items[0];",
+                  "",
+                  "        tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "        tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "        tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "        tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "        tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "        tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "        tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "        tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "        tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "        tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "        tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "        tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "        tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "        tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  "    } else {",
+                  "        tests['itemsCount is 0 when feed is empty'] = responseJSON.itemsCount === 0;",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": {
               "raw": "{{apiUrl}}/items?tag=dragons",
-              "host": [
-                "{{apiUrl}}"
+              "host": ["{{apiUrl}}"],
+              "path": ["items"],
+              "query": [
+                {
+                  "key": "tag",
+                  "value": "dragons"
+                }
               ],
-              "path": [
-                "items"
-              ],
-              "query": [{
-                "key": "tag",
-                "value": "dragons"
-              }],
               "variable": []
             },
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1464,39 +1518,42 @@
         },
         {
           "name": "Single Item by slug",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
-                "",
-                "var item = responseJSON.item || {};",
-                "",
-                "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
-                "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
-                "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
-                "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
-                "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
-                "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
-                "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
-                "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
-                "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
-                "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
-                "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
-                "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
-                "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
-                "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"item\" property'] = responseJSON.hasOwnProperty('item');",
+                  "",
+                  "var item = responseJSON.item || {};",
+                  "",
+                  "tests['Item has \"title\" property'] = item.hasOwnProperty('title');",
+                  "tests['Item has \"slug\" property'] = item.hasOwnProperty('slug');",
+                  "tests['Item has \"body\" property'] = item.hasOwnProperty('body');",
+                  "tests['Item has \"createdAt\" property'] = item.hasOwnProperty('createdAt');",
+                  "tests['Item\\'s \"createdAt\" property is an ISO 8601 timestamp'] = new Date(item.createdAt).toISOString() === item.createdAt;",
+                  "tests['Item has \"updatedAt\" property'] = item.hasOwnProperty('updatedAt');",
+                  "tests['Item\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = new Date(item.updatedAt).toISOString() === item.updatedAt;",
+                  "tests['Item has \"description\" property'] = item.hasOwnProperty('description');",
+                  "tests['Item has \"tagList\" property'] = item.hasOwnProperty('tagList');",
+                  "tests['Item\\'s \"tagList\" property is an Array'] = Array.isArray(item.tagList);",
+                  "tests['Item has \"seller\" property'] = item.hasOwnProperty('seller');",
+                  "tests['Item has \"favorited\" property'] = item.hasOwnProperty('favorited');",
+                  "tests['Item has \"favoritesCount\" property'] = item.hasOwnProperty('favoritesCount');",
+                  "tests['favoritesCount is an integer'] = Number.isInteger(item.favoritesCount);",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1517,42 +1574,46 @@
     {
       "name": "Comments",
       "description": "",
-      "item": [{
+      "item": [
+        {
           "name": "All Comments for Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var is200Response = responseCode.code === 200",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"comments\" property'] = responseJSON.hasOwnProperty('comments');",
-                "",
-                "    if(responseJSON.comments.length){",
-                "        var comment = responseJSON.comments[0];",
-                "",
-                "        tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
-                "        tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
-                "        tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
-                "        tests['\"createdAt\" property is an ISO 8601 timestamp'] = new Date(comment.createdAt).toISOString() === comment.createdAt;",
-                "        tests['Comment has \"updatedAt\" property'] = comment.hasOwnProperty('updatedAt');",
-                "        tests['\"updatedAt\" property is an ISO 8601 timestamp'] = new Date(comment.updatedAt).toISOString() === comment.updatedAt;",
-                "        tests['Comment has \"seller\" property'] = comment.hasOwnProperty('seller');",
-                "    }",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"comments\" property'] = responseJSON.hasOwnProperty('comments');",
+                  "",
+                  "    if(responseJSON.comments.length){",
+                  "        var comment = responseJSON.comments[0];",
+                  "",
+                  "        tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
+                  "        tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
+                  "        tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
+                  "        tests['\"createdAt\" property is an ISO 8601 timestamp'] = new Date(comment.createdAt).toISOString() === comment.createdAt;",
+                  "        tests['Comment has \"updatedAt\" property'] = comment.hasOwnProperty('updatedAt');",
+                  "        tests['\"updatedAt\" property is an ISO 8601 timestamp'] = new Date(comment.updatedAt).toISOString() === comment.updatedAt;",
+                  "        tests['Comment has \"seller\" property'] = comment.hasOwnProperty('seller');",
+                  "    }",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}/comments",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1575,30 +1636,33 @@
         },
         {
           "name": "Create Comment for Item",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "var responseJSON = JSON.parse(responseBody);",
-                "",
-                "tests['Response contains \"comment\" property'] = responseJSON.hasOwnProperty('comment');",
-                "",
-                "var comment = responseJSON.comment || {};",
-                "",
-                "tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
-                "tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
-                "tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
-                "tests['\"createdAt\" property is an ISO 8601 timestamp'] = new Date(comment.createdAt).toISOString() === comment.createdAt;",
-                "tests['Comment has \"seller\" property'] = comment.hasOwnProperty('seller');",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "tests['Response contains \"comment\" property'] = responseJSON.hasOwnProperty('comment');",
+                  "",
+                  "var comment = responseJSON.comment || {};",
+                  "",
+                  "tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
+                  "tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
+                  "tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
+                  "tests['\"createdAt\" property is an ISO 8601 timestamp'] = new Date(comment.createdAt).toISOString() === comment.createdAt;",
+                  "tests['Comment has \"seller\" property'] = comment.hasOwnProperty('seller');",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}/comments",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1627,7 +1691,8 @@
           "request": {
             "url": "{{apiUrl}}/items/{{slug}}/comments/1",
             "method": "DELETE",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1653,38 +1718,42 @@
     {
       "name": "Profiles",
       "description": "",
-      "item": [{
+      "item": [
+        {
           "name": "Profile",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "if (!(environment.isIntegrationTest)) {",
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
-                "    ",
-                "    var profile = responseJSON.profile || {};",
-                "    ",
-                "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
-                "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
-                "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
-                "}",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!(environment.isIntegrationTest)) {",
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
+                  "    ",
+                  "    var profile = responseJSON.profile || {};",
+                  "    ",
+                  "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
+                  "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
+                  "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
+                  "}",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/profiles/johnjacob",
             "method": "GET",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1707,37 +1776,40 @@
         },
         {
           "name": "Follow Profile",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "if (!(environment.isIntegrationTest)) {",
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
-                "    ",
-                "    var profile = responseJSON.profile || {};",
-                "    ",
-                "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
-                "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
-                "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
-                "    tests['Profile\\'s \"following\" property is true'] = profile.following === true;",
-                "}",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!(environment.isIntegrationTest)) {",
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
+                  "    ",
+                  "    var profile = responseJSON.profile || {};",
+                  "    ",
+                  "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
+                  "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
+                  "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
+                  "    tests['Profile\\'s \"following\" property is true'] = profile.following === true;",
+                  "}",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/profiles/johnjacob/follow",
             "method": "POST",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1763,37 +1835,40 @@
         },
         {
           "name": "Unfollow Profile",
-          "event": [{
-            "listen": "test",
-            "script": {
-              "type": "text/javascript",
-              "exec": [
-                "if (!(environment.isIntegrationTest)) {",
-                "var is200Response = responseCode.code === 200;",
-                "",
-                "tests['Response code is 200 OK'] = is200Response;",
-                "",
-                "if(is200Response){",
-                "    var responseJSON = JSON.parse(responseBody);",
-                "",
-                "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
-                "    ",
-                "    var profile = responseJSON.profile || {};",
-                "    ",
-                "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
-                "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
-                "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
-                "    tests['Profile\\'s \"following\" property is false'] = profile.following === false;",
-                "}",
-                "}",
-                ""
-              ]
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!(environment.isIntegrationTest)) {",
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "",
+                  "    tests['Response contains \"profile\" property'] = responseJSON.hasOwnProperty('profile');",
+                  "    ",
+                  "    var profile = responseJSON.profile || {};",
+                  "    ",
+                  "    tests['Profile has \"username\" property'] = profile.hasOwnProperty('username');",
+                  "    tests['Profile has \"image\" property'] = profile.hasOwnProperty('image');",
+                  "    tests['Profile has \"following\" property'] = profile.hasOwnProperty('following');",
+                  "    tests['Profile\\'s \"following\" property is false'] = profile.following === false;",
+                  "}",
+                  "}",
+                  ""
+                ]
+              }
             }
-          }],
+          ],
           "request": {
             "url": "{{apiUrl}}/profiles/johnjacob/follow",
             "method": "DELETE",
-            "header": [{
+            "header": [
+              {
                 "key": "Content-Type",
                 "value": "application/json",
                 "description": ""
@@ -1819,82 +1894,90 @@
     {
       "name": "Tags",
       "description": "",
-      "item": [{
-        "name": "All Tags",
-        "event": [{
-          "listen": "test",
-          "script": {
-            "type": "text/javascript",
-            "exec": [
-              "var is200Response = responseCode.code === 200;",
-              "",
-              "tests['Response code is 200 OK'] = is200Response;",
-              "",
-              "if(is200Response){",
-              "    var responseJSON = JSON.parse(responseBody);",
-              "    ",
-              "    tests['Response contains \"tags\" property'] = responseJSON.hasOwnProperty('tags');",
-              "    tests['\"tags\" property returned as array'] = Array.isArray(responseJSON.tags);",
-              "}",
-              ""
-            ]
-          }
-        }],
-        "request": {
-          "url": "{{apiUrl}}/tags",
-          "method": "GET",
-          "header": [{
-              "key": "Content-Type",
-              "value": "application/json",
-              "description": ""
-            },
+      "item": [
+        {
+          "name": "All Tags",
+          "event": [
             {
-              "key": "X-Requested-With",
-              "value": "XMLHttpRequest",
-              "description": ""
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var is200Response = responseCode.code === 200;",
+                  "",
+                  "tests['Response code is 200 OK'] = is200Response;",
+                  "",
+                  "if(is200Response){",
+                  "    var responseJSON = JSON.parse(responseBody);",
+                  "    ",
+                  "    tests['Response contains \"tags\" property'] = responseJSON.hasOwnProperty('tags');",
+                  "    tests['\"tags\" property returned as array'] = Array.isArray(responseJSON.tags);",
+                  "}",
+                  ""
+                ]
+              }
             }
           ],
-          "body": {
-            "mode": "raw",
-            "raw": ""
+          "request": {
+            "url": "{{apiUrl}}/tags",
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "description": ""
+              },
+              {
+                "key": "X-Requested-With",
+                "value": "XMLHttpRequest",
+                "description": ""
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": ""
+            },
+            "description": ""
           },
-          "description": ""
-        },
-        "response": []
-      }]
+          "response": []
+        }
+      ]
     },
     {
       "name": "Cleanup",
       "description": "",
-      "item": [{
-        "name": "Delete Item",
-        "request": {
-          "url": "{{apiUrl}}/items/{{slug}}",
-          "method": "DELETE",
-          "header": [{
-              "key": "Content-Type",
-              "value": "application/json",
-              "description": ""
+      "item": [
+        {
+          "name": "Delete Item",
+          "request": {
+            "url": "{{apiUrl}}/items/{{slug}}",
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "description": ""
+              },
+              {
+                "key": "X-Requested-With",
+                "value": "XMLHttpRequest",
+                "description": ""
+              },
+              {
+                "key": "Authorization",
+                "value": "Token {{token}}",
+                "description": ""
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": ""
             },
-            {
-              "key": "X-Requested-With",
-              "value": "XMLHttpRequest",
-              "description": ""
-            },
-            {
-              "key": "Authorization",
-              "value": "Token {{token}}",
-              "description": ""
-            }
-          ],
-          "body": {
-            "mode": "raw",
-            "raw": ""
+            "description": ""
           },
-          "description": ""
-        },
-        "response": []
-      }]
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/backend/tests/env-api-tests.postman.json
+++ b/backend/tests/env-api-tests.postman.json
@@ -1,12 +1,14 @@
 {
   "id": "4aa60b52-97fc-456d-4d4f-14a350e95dff",
   "name": "Anythink-Market API Tests - Environment",
-  "values": [{
-    "enabled": true,
-    "key": "apiUrl",
-    "value": "http://localhost:3000/api",
-    "type": "text"
-  }],
+  "values": [
+    {
+      "enabled": true,
+      "key": "apiUrl",
+      "value": "http://localhost:3000/api",
+      "type": "text"
+    }
+  ],
   "timestamp": 1505871382668,
   "_postman_variable_scope": "environment",
   "_postman_exported_at": "2017-09-20T01:36:34.835Z",


### PR DESCRIPTION
# Description

There was an issue with broken images being displayed on the front-end when an item image URL was not entered. While this was fixed on the UI, broken images were still showing up due to no placeholder for this on the backend.